### PR TITLE
Force index server to use IPv4 localhost address

### DIFF
--- a/index.js
+++ b/index.js
@@ -392,7 +392,7 @@ if (API_KEY.androidId && API_KEY.masterToken) {
 	// Audioshield expects HTTPS port 443
 	pm.init({ androidId: API_KEY.androidId, masterToken: API_KEY.masterToken }, () => {
 		var httpsServer = https.createServer(options, app);
-		httpsServer.listen(443);
+		httpsServer.listen(443, '127.0.0.1');
 		console.log('Server running');
 		console.log('CTRL+C to shutdown');
 	});


### PR DESCRIPTION
Sometimes machines will automatically assign an IPv6 address to the node server rather than an IPv4 address (127.0.0.1) which is where the proxy server is redirecting to.
